### PR TITLE
fix graphml output to allow posixpath

### DIFF
--- a/src/graph.py
+++ b/src/graph.py
@@ -802,7 +802,7 @@ def output_networkx_graph_as_graphml_for_cytoscape(nxgraph, output_dir=".", file
     path = Path(output_dir)
     path.mkdir(exist_ok=True, parents=True)
     path = path / filename
-    nx.write_graphml(nxgraph, path)
+    nx.write_graphml(nxgraph, str(path))
 
     return path.resolve()
 


### PR DESCRIPTION
The networkx method `write_graphml` does not allow PosixPath objects as input.