### PR TITLE
Fix doc for input files and disable missing value parsing

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -27,9 +27,9 @@ def directory(dirname):
 io_params = parser.add_argument_group("Input / Output Files")
 
 io_params.add_argument("-e", "--edge", dest='edge_file', type=str, required=True,
-    help ='(Required) Path to the text file containing the edges. Should be a tab delimited file (no header) with 3 columns: "nodeA\tnodeB\tcost"')
+    help ='(Required) Path to the text file containing the edges. Should be a tab delimited file (*with* header) with 3 columns: "protein1\tprotein2\tcost"')
 io_params.add_argument("-p", "--prize", dest='prize_file', type=str, required=True,
-    help='(Required) Path to the text file containing the prizes. Should be a tab delimited file (*with* header) with lines: "nodeName(tab)prize"')
+    help='(Required) Path to the text file containing the prizes. Should be a tab delimited file (*with* header) with lines: "name\tprize"')
 io_params.add_argument('-o', '--output', dest='output_dir', action=FullPaths, type=directory, required=True,
     help='(Required) Output directory path')
 

--- a/src/graph.py
+++ b/src/graph.py
@@ -83,7 +83,7 @@ class Graph:
             params (dict): params with which to run the program
         """
 
-        self.interactome_dataframe = pd.read_csv(interactome_file, sep='\t')
+        self.interactome_dataframe = pd.read_csv(interactome_file, sep='\t', na_filter=False)
         self.interactome_graph = nx.from_pandas_edgelist(self.interactome_dataframe, 'protein1', 'protein2', edge_attr=self.interactome_dataframe.columns[2:].tolist())
 
         # Convert the interactome dataframe from string interactor IDs to integer interactor IDs.
@@ -165,7 +165,7 @@ class Graph:
             prize_file (str or FILE): a filepath or file object containing a tsv **with column headers**.
         """
 
-        prizes_dataframe = pd.read_csv(prize_file, sep='\t')
+        prizes_dataframe = pd.read_csv(prize_file, sep='\t', na_filter=False)
         prizes_dataframe.columns = ['name', 'prize'] + prizes_dataframe.columns[2:].tolist()
         prizes_dataframe['prize'] = pd.to_numeric(prizes_dataframe['prize'])
 


### PR DESCRIPTION
Hi everyone,

I ran into a problem where some of my nodes where called "NA" and pandas interpreted these as missing values. Since missing values are not allowed as input anyways, I thought parsing them could just be disabled.

Also, I think the description of the input file format was outdated.

Let me know what you think.