### PR TITLE
Resolve package dependencies for installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy>=1.12.0
-pandas>=0.21.1
+pandas==0.23.4
 scikit-learn>=0.19.0
-networkx>=2.1
-pcst_fast>=1.0.6
+networkx==2.1
+pcst_fast==1.0.7
 jinja2>=2.9
 python-louvain>=0.9
 goenrich==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pcst_fast==1.0.7
 jinja2>=2.9
 python-louvain>=0.9
 goenrich==1.7.0
-axial>=0.0.4
+axial>=0.1.10
 scipy>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "pcst_fast==1.0.7",
         "python-louvain",
         "goenrich",
-        "sklearn",
+        "scikit-learn",
         "axial",
         "scipy"
     ],


### PR DESCRIPTION
Requiring `sklearn` in `setup.py` installs the wrong package.  The other changes make `requirements.txt` more consistent with `setup.py`.

I found it tricky to install this package from `requirements.txt` and created a compatible conda environment.  I have that on a separate branch and could merge it here if you are interested.